### PR TITLE
Pin to a working image

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
 services:
   splunk:
-    image: splunk/splunk:latest
+    image: splunk/splunk:9.4
     environment:
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_PASSWORD=password


### PR DESCRIPTION
Splunk 10 was [released](https://www.splunk.com/en_us/blog/platform/introducing-splunk-10-empowering-a-secure-and-compliant-future.html) and apparently changes default listening ports.

Pin to the last-known good version 9.4.

Fixes https://github.com/pulumi/pulumi-splunk/issues/657.