### PR TITLE
testing: pass another license-related envvar

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   splunk:
     image: splunk/splunk:9.4
+    platform: linux/amd64
     environment:
+      - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_PASSWORD=password
     ports:


### PR DESCRIPTION
These changes set the value of the `SPLUNK_GENERAL_TERMS` environment
variable to `--accept-sgt-current-at-splunk-com` when starting splunk
via `docker compose`. This unblocks our ability to run tests.

Fixes #719.
